### PR TITLE
Fixed regex for protocols.

### DIFF
--- a/src/chupa-cabra.js
+++ b/src/chupa-cabra.js
@@ -79,11 +79,11 @@ exports.validateURL = function(url){
 // };
 
 exports.isHttp = function(url){
-  return url.match(/http:\/\//) != null ? true : false;
+  return url.match(/^http:\/\//) != null ? true : false;
 };
 
 exports.isHttps = function(url){
-  return url.match(/https:\/\//) != null ? true : false;
+  return url.match(/^https:\/\//) != null ? true : false;
 };
 
 exports.forceHttp = function(url){

--- a/src/chupa-cabra.js
+++ b/src/chupa-cabra.js
@@ -79,11 +79,11 @@ exports.validateURL = function(url){
 // };
 
 exports.isHttp = function(url){
-  return url.match(/^http:\/\//) != null ? true : false;
+  return !!(url.match(/^http:\/\//) != null);
 };
 
 exports.isHttps = function(url){
-  return url.match(/^https:\/\//) != null ? true : false;
+  return !!(url.match(/^https:\/\//) != null);
 };
 
 exports.forceHttp = function(url){


### PR DESCRIPTION
The previous `/http:\/\//` definition was able to match `http` in the body of the strings. It must match only the start of it. Fixed with usage of `^`.
